### PR TITLE
Fixed the org.eclipse.m2e lifecycle warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<team.group.id>cotiviti</team.group.id>
 		<jenkins.url>https://nexgen-admin.ci.cloudbees.com/job/OSS</jenkins.url>
 
-		<!-- The base URL to nexus. This is for repositories and possibly weird 
+		<!-- The base URL to nexus. This is for repositories and possibly weird
 			stuff we might do to nexus -->
 
 		<ghe.host>github.com</ghe.host>
@@ -82,7 +82,7 @@
 		<!-- The base url of a bitbucket project -->
 		<git.url.base>git@github.com:${team.group.id}</git.url.base>
 
-		<!-- The URL of a given project. This works with inheritence but probably 
+		<!-- The URL of a given project. This works with inheritence but probably
 			not multi-module -->
 		<github.site.plugin.version>0.11</github.site.plugin.version>
 		<git.url>${git.url.base}/${project.artifactId}.git</git.url>
@@ -173,7 +173,7 @@
 		<tag>HEAD</tag>
 	</scm>
 
-	<!-- Currently nothing for site deployments, but that's coming in a future 
+	<!-- Currently nothing for site deployments, but that's coming in a future
 		version -->
 	<distributionManagement>
 		<snapshotRepository>
@@ -354,8 +354,8 @@
 							<totalLineRate>${test.coverage.percentage.required}</totalLineRate>
 							<packageLineRate>${test.coverage.percentage.required}</packageLineRate>
 							<packageBranchRate>${test.coverage.percentage.required}</packageBranchRate>
-							<!-- <regexes> <regex> <pattern>com.example.reallyimportant.*</pattern> 
-								<branchRate>90</branchRate> <lineRate>80</lineRate> </regex> <regex> <pattern>com.example.boringcode.*</pattern> 
+							<!-- <regexes> <regex> <pattern>com.example.reallyimportant.*</pattern>
+								<branchRate>90</branchRate> <lineRate>80</lineRate> </regex> <regex> <pattern>com.example.boringcode.*</pattern>
 								<branchRate>40</branchRate> <lineRate>30</lineRate> </regex> </regexes> -->
 						</check>
 					</configuration>
@@ -522,36 +522,6 @@
 						</tanukisoftJSW>
 					</configuration>
 				</plugin>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>com.mycila</groupId>
-										<artifactId>
-											license-maven-plugin
-										</artifactId>
-										<versionRange>
-											[2.11,)
-										</versionRange>
-										<goals>
-											<goal>format</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 		<resources>
@@ -695,6 +665,58 @@
 		</plugins>
 	</reporting>
 	<profiles>
+		<profile>
+<!-- This profile will only be executed when maven is run from the m2e plugin in eclipse, as it is the only entity which sets the `m2e.version` property. This
+     is here to prevent the annoying warning which comes up when you run maven outside of an m2e environment. An example of this error is below.
+
+     [WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
+     [WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Failure to find org.ecli
+     pse.m2e:lifecycle-mapping:jar:1.0.0 in https://someplace was cached in the local repository, resolution will not be reattempted until the update int
+     erval of remote-repos has elapsed or updates are forced -->
+			<id>only-eclipse</id>
+			<activation>
+				<property>
+					<name>m2e.version</name>
+				</property>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<!--This plugin's configuration is used to store Eclipse m2e settings
+							only. It has no influence on the Maven build itself. -->
+						<plugin>
+							<groupId>org.eclipse.m2e</groupId>
+							<artifactId>lifecycle-mapping</artifactId>
+							<version>1.0.0</version>
+							<configuration>
+								<lifecycleMappingMetadata>
+									<pluginExecutions>
+										<pluginExecution>
+											<pluginExecutionFilter>
+												<groupId>com.mycila</groupId>
+												<artifactId>
+													license-maven-plugin
+												</artifactId>
+												<versionRange>
+													[2.11,)
+												</versionRange>
+												<goals>
+													<goal>format</goal>
+												</goals>
+											</pluginExecutionFilter>
+											<action>
+												<ignore />
+											</action>
+										</pluginExecution>
+									</pluginExecutions>
+								</lifecycleMappingMetadata>
+							</configuration>
+						</plugin>
+
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>


### PR DESCRIPTION
* This warning is generated every time this POM is used outside of
  eclipse. This update sets a profile that only enables the lifecycle
  plugin when the `m2e.version` property is set, which is only set in
  that environment.
* See this SO post for an explanation https://stackoverflow.com/questions/7905501/get-rid-of-pom-not-found-warning-for-org-eclipse-m2elifecycle-mapping
* Example of said warning

```shell
[WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
[WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Failure to find org.ecli
pse.m2e:lifecycle-mapping:jar:1.0.0 in https://ihealthtechnologies.artifactoryonline.com/ihealthtechnologies/remote-repos was cached in the local repository, resolution will not be reattempted until the update int
erval of remote-repos has elapsed or updates are forced
```