### PR TITLE
Fixed default scala compiler flags.

### DIFF
--- a/cotiviti-nexgen-parent/pom.xml
+++ b/cotiviti-nexgen-parent/pom.xml
@@ -885,10 +885,9 @@
 						<args>
 							<arg>-unchecked</arg>
 							<arg>-deprecation</arg>
+	                                                <arg>-feature</arg>
 							<arg>-Xlint</arg>
-							<!-- <arg>–Xfatal-warnings</arg> -->
 							<arg>-Ywarn-dead-code</arg>
-							<arg>-language:_</arg>
 							<arg>-target:jvm-${maven.compiler.jdk.version}</arg>
 						</args>
 					</configuration>
@@ -945,4 +944,3 @@
 		<module>cotiviti-rpms-parent</module>
 	</modules>
 </project>
-


### PR DESCRIPTION
* Previously the compiler flags were set to ignore use of
  experimental/advanced language features. There is no reason to turn
  off these warnings globally.
* Added in `-feature` that will warn about use of advanced/experimental
  language features unless they are explicitly imported, as is
  considered best practice.