### PR TITLE
avro property fix

### DIFF
--- a/cotiviti-nexgen-parent/pom.xml
+++ b/cotiviti-nexgen-parent/pom.xml
@@ -128,7 +128,6 @@
 		<fge.json.schema.validator>2.2.6</fge.json.schema.validator>
 		<jackson.version>2.5.1</jackson.version>
 		<vertx.version>3.2.0</vertx.version>
-		<avro.core.version>1.8.0</avro.core.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
 		<apache.commons.lang.version>2.6</apache.commons.lang.version>
 		<apache.commons.lang3.version>3.4</apache.commons.lang3.version>
 
+		<avro.core.version>1.8.0</avro.core.version>
 	</properties>
 
 	<!-- URL for site gen -->


### PR DESCRIPTION
avro.core.version is used in the base pom but declared in a sub directory