### PR TITLE
Make commons-io not provided.

### DIFF
--- a/cotiviti-nexgen-parent/pom.xml
+++ b/cotiviti-nexgen-parent/pom.xml
@@ -50,7 +50,7 @@
 		<scala.stack.max.mb>2048</scala.stack.max.mb>
 
 		<!-- Some dependency versions, because sometimes that's nice to mess with -->
-<!-- 	Set in the parent	
+<!-- 	Set in the parent
 		<spring.version>4.1.4.RELEASE</spring.version>
 		<spring.boot.version>1.3.1.RELEASE</spring.boot.version>
  -->
@@ -527,7 +527,6 @@
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>${commons.io.version}</version>
-				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>commons-pool</groupId>


### PR DESCRIPTION
I can't see any reason this is scoped as `provided`. It causes my builds to crash once every two weeks.