### PR TITLE
Added emacs files to the ignore license config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,10 @@
 							<exclude>src/test/resources/**</exclude>
 							<exclude>src/main/resources/**</exclude>
 							<exclude>src/main/avro/**</exclude>
+	                                                <exclude>**/.dir-locals.el</exclude>
+	                                                <exclude>**.ensime_cache/</exclude>
+	                                                <exclude>.ensime*</exclude>
+	                                                <exclude>scalastyle_config.xml</exclude>
 						</excludes>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
These files are used by emacs and emacs related scala packages, we don't need to license them (in fact adding license breaks them).