### PR TITLE
Added scala-library as an explicit dependency for cotivit-scala-parent.

### DIFF
--- a/cotiviti-nexgen-parent/cotiviti-scala-parent/pom.xml
+++ b/cotiviti-nexgen-parent/cotiviti-scala-parent/pom.xml
@@ -44,6 +44,10 @@
 	</dependencyManagement>
 	<dependencies>
 		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_${scala.minor.version}</artifactId>
 			<scope>test</scope>
@@ -54,9 +58,6 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<configuration>
-					<scalaCompatVersion>${scala.minor.version}</scalaCompatVersion>
-				</configuration>
 				<executions>
 					<execution>
 						<goals>
@@ -102,9 +103,9 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- <plugin> <groupId>org.scalatest</groupId> <artifactId>scalatest-maven-plugin</artifactId> 
-				</plugin> <plugin> <groupId>org.scoverage</groupId> <artifactId>scoverage-maven-plugin</artifactId> 
-				<executions> <execution> <id>check-scoverage-coverage</id> <phase>test</phase> 
+			<!-- <plugin> <groupId>org.scalatest</groupId> <artifactId>scalatest-maven-plugin</artifactId>
+				</plugin> <plugin> <groupId>org.scoverage</groupId> <artifactId>scoverage-maven-plugin</artifactId>
+				<executions> <execution> <id>check-scoverage-coverage</id> <phase>test</phase>
 				<goals> <goal>check</goal> </goals> </execution> </executions> </plugin> -->
 		</plugins>
 	</build>

--- a/cotiviti-nexgen-parent/pom.xml
+++ b/cotiviti-nexgen-parent/pom.xml
@@ -957,7 +957,7 @@
 					<artifactId>scala-maven-plugin</artifactId>
 					<version>${scala.maven.plugin.version}</version>
 					<configuration>
-						<scalaVersion>${scala.version}</scalaVersion>
+  					        <scalaCompatVersion>${scala.minor.version}</scalaCompatVersion>
 						<encoding>UTF-8</encoding>
 						<useZincServer>false</useZincServer>
 						<jvmArgs>


### PR DESCRIPTION
* Moved all the configuration of the scala-maven-plugin to the
  cotiviti-nextgen-parent, before it was split between that and
  cotiviti-scala-parent.
* Made the dependency on `scala-library` explicit.