### PR TITLE
Removed duplicate reference to wagon.

### DIFF
--- a/cotiviti-nexgen-parent/pom.xml
+++ b/cotiviti-nexgen-parent/pom.xml
@@ -32,7 +32,6 @@
 	<properties>
 		<aether.version>1.1.0</aether.version>
 		<maven.version>3.3.9</maven.version>
-		<wagon.version>2.10</wagon.version>
 		<pax.url.version>2.4.7</pax.url.version>
 		<sbt-compiler.plugin.version>1.0.0-beta5</sbt-compiler.plugin.version>
 		<scoverage.maven.plugin.version>1.1.1</scoverage.maven.plugin.version>
@@ -647,11 +646,6 @@
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-aether-provider</artifactId>
 				<version>${maven.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ssh</artifactId>
-				<version>${wagon.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openrdf.sesame</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<maven.pmd.plugin.version>3.5</maven.pmd.plugin.version>
 		<maven.jdepend.plugin.version>2.0</maven.jdepend.plugin.version>
 		<maven.taglist.plugin.version>2.4</maven.taglist.plugin.version>
-		<maven.wagon.ssh.version>2.9</maven.wagon.ssh.version>
+		<maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
 		<maven.graph.plugin.version>1.2.3</maven.graph.plugin.version>
 		<maven.archetype.plugin.version>2.4</maven.archetype.plugin.version>
 		<maven.war.plugin.version>2.6</maven.war.plugin.version>


### PR DESCRIPTION
* `org.apache.maven.wagon` was defined in `<dependencyManagement>` in
  both the `cotivit-parent` and `cotiviti-nextgen-parent`. They were
  also at slightly different versions. I removed the definition in
  nextgen and unified the versions on the higher of the two.